### PR TITLE
Fix AddSample() crash

### DIFF
--- a/NachoPlatformLib/NachoPlatformLib/PlatformProcess.h
+++ b/NachoPlatformLib/NachoPlatformLib/PlatformProcess.h
@@ -11,7 +11,7 @@
 
 @interface PlatformProcess : NSObject
 
-+ (long)getUsedMemory;
++ (long long)getUsedMemory;
 
 + (int)getCurrentNumberOfFileDescriptors;
 

--- a/NachoPlatformLib/NachoPlatformLib/PlatformProcess.m
+++ b/NachoPlatformLib/NachoPlatformLib/PlatformProcess.m
@@ -18,13 +18,13 @@
 
 @implementation PlatformProcess
 
-+ (long)getUsedMemory
++ (long long)getUsedMemory
 {
     struct task_basic_info info;
     mach_msg_type_number_t size = sizeof(info);
     kern_return_t kerr = task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&info, &size);
     vm_size_t process_size = (kerr == KERN_SUCCESS) ? info.resident_size : 0; // size in bytes
-    return process_size;
+    return (long long)process_size;
 }
 
 + (int)getCurrentNumberOfFileDescriptors


### PR DESCRIPTION
- long is 4 bytes in 32-bit iOS devices and 8 bytes in 64-bit devices. 
- Use long long instead to match 64-bit C# long.
